### PR TITLE
Add resume sync improvements, date normalization, and macOS automation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Power users can also consider running local LLMs.
 * [⚙️ Advanced Options & Google Sheets Integration](#advanced-options--google-sheets-integration)
     * [Optional: Use a Python Virtual Environment](#optional-use-a-python-virtual-environment)
     * [Optional: Running as a Scheduled Task](#optional-running-as-a-scheduled-task)
+    * [Optional: Automating Daily Sync on macOS](#optional-automating-daily-sync-on-macos)
     * [🔑 Google API Setup (for Google Sheets Output)](#google-api-setup-for-google-sheets-output)
     * [▶️ Running for Google Sheets Output:](#running-for-google-sheets-output)
 * [📊 Available Metrics](#available-metrics)
@@ -178,6 +179,49 @@ python -m src.main cli-sync --start-date YYYY-MM-DD --end-date YYYY-MM-DD --prof
 ```
 Ensure you are in the project's root directory when using `python -m src.main`.
 
+### Optional: Automating Daily Sync on macOS
+
+If you want your Garmin data to sync automatically each day, you can use macOS’s built-in launchd scheduler. The LaunchAgent calls the helper script run_garmingo.sh. This script runs the sync for both configured users, resuming from the last logged date up to yesterday by default.
+Example run_garmingo.sh (included in the repo):
+```#!/bin/bash
+cd /Users/$USER/jg-garmin-to-sheets-main
+/Users/$USER/jg-garmin-to-sheets-main/venv/bin/python3 -m src.main cli-sync --profile USER1 --output-type sheets --resume --end-offset 1
+/Users/$USER/jg-garmin-to-sheets-main/venv/bin/python3 -m src.main cli-sync --profile USER2 --output-type sheets --resume --end-offset 1
+```
+*   --resume tells it to continue from the last date in Google Sheets.
+*   --end-offset 1 makes it stop at yesterday (to avoid syncing partial data from today).
+
+You can edit this script to run only one user, or change profiles/dates if needed.
+A sample LaunchAgent configuration file is included in this repository:
+com.garmingo.sync.plist
+
+Setup Instructions
+1.  Edit the plist file
+Open com.garmingo.sync.plist in a text editor and update the paths:
+*   Replace /Users/$USER/ with your actual macOS username if it doesn’t resolve automatically.
+*   Adjust the Hour and Minute values under <StartCalendarInterval> to the time you want the sync to run (default is 9:30 AM).
+2.  Copy it to LaunchAgents
+```
+mkdir -p ~/Library/LaunchAgents
+cp com.garmingo.sync.plist ~/Library/LaunchAgents/
+```
+3.  Load the LaunchAgent
+```
+launchctl load ~/Library/LaunchAgents/com.garmingo.sync.plist
+```
+To start it immediately (without waiting for the scheduled time):
+```
+launchctl start com.garmingo.sync
+```
+4. Check Logs
+*   Standard output is logged to /tmp/garmingo.log
+*   Errors are logged to /tmp/garmingo.err
+5.  Unload later (optional)
+    If you want to disable the automation:
+```
+launchctl unload ~/Library/LaunchAgents/com.garmingo.sync.plist
+```
+
 ### 🔑 Google API Setup (for Google Sheets Output)
 
 To send data to Google Sheets, you need to set up Google API credentials.
@@ -264,7 +308,7 @@ The tool syncs the following daily metrics from Garmin Connect:
 
 Want a metric added? Just raise an Issue and request it!
 
----
+---   
 
 ## 🛠️ Troubleshooting
 

--- a/com.garmingo.sync.plist
+++ b/com.garmingo.sync.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.garmingo.sync</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/$USER/jg-garmin-to-sheets-main/run_garmingo.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/$USER/jg-garmin-to-sheets-main</string>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/garmingo.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/garmingo.err</string>
+
+    <!-- Run at 9:30 AM every day -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+</dict>
+</plist>

--- a/run_garmingo.sh
+++ b/run_garmingo.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+cd /Users/$USER/jg-garmin-to-sheets-main
+
+# Run for USER1
+/Users/$USER/jg-garmin-to-sheets-main/venv/bin/python3 -m src.main \
+  --profile USER1 \
+  --output-type sheets \
+  --resume \
+  --end-offset 1
+
+# Run for USER2
+/Users/$USER/jg-garmin-to-sheets-main/venv/bin/python3 -m src.main \
+  --profile USER2 \
+  --output-type sheets \
+  --resume \
+  --end-offset 1

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ import logging
 import re
 
 from src.garmin_client import GarminClient
-from src.sheets_client import GoogleSheetsClient, GoogleAuthTokenRefreshError
+from src.sheets_client import GoogleSheetsClient, GoogleAuthTokenRefreshError, normalize_date
 from src.exceptions import MFARequiredException
 from src.config import HEADERS, HEADER_TO_ATTRIBUTE_MAP, GarminMetrics
 
@@ -153,12 +153,59 @@ def load_user_profiles():
             profiles[profile_name][key_map[var_type]] = value
     return profiles
 
+def get_last_logged_date_from_sheets(profile_data: dict) -> Optional[date]:
+    try:
+        sheets_client = GoogleSheetsClient(
+            credentials_path='credentials/client_secret.json',
+            spreadsheet_id=profile_data.get('sheet_id'),
+            sheet_name=profile_data.get('sheet_name', 'Raw Data')
+        )
+        result = sheets_client.service.spreadsheets().values().get(
+            spreadsheetId=profile_data.get('sheet_id'),
+            range=f"'{profile_data.get('sheet_name', 'Raw Data')}'!A:A"
+        ).execute()
+        values = result.get('values', [])
+        if not values or len(values) <= 1:
+            return None
+
+        # skip header row
+        values = values[1:]
+        latest = None
+        for row in values:
+            if not row or not row[0]:
+                continue
+            norm = normalize_date(row[0])   # 🔹 normalize whatever’s in the sheet
+            try:
+                d = datetime.fromisoformat(norm).date()
+                if not latest or d > latest:
+                    latest = d
+            except Exception:
+                continue
+        return latest
+    except Exception as e:
+        logger.warning(f"Could not fetch last logged date: {e}")
+        return None
+
+def compute_resume_range(profile_data: dict, end_offset: int = 1) -> tuple[date, date]:
+    today = datetime.today().date()
+    end = today - timedelta(days=end_offset)
+    last = get_last_logged_date_from_sheets(profile_data)
+    if last:
+        start = last + timedelta(days=1)
+    else:
+        start = end - timedelta(days=30)  # fallback
+    if end < start:
+        end = start
+    return start, end
+
 @app.command()
 def cli_sync(
-    start_date: datetime = typer.Option(..., help="Start date in YYYY-MM-DD format."),
-    end_date: datetime = typer.Option(..., help="End date in YYYY-MM-DD format."),
+    start_date: Optional[datetime] = typer.Option(None, help="Start date in YYYY-MM-DD format."),
+    end_date: Optional[datetime] = typer.Option(None, help="End date in YYYY-MM-DD format."),
     profile: str = typer.Option("USER1", help="The user profile from .env to use (e.g., USER1)."),
-    output_type: str = typer.Option("sheets", help="Output type: 'sheets' or 'csv'.")
+    output_type: str = typer.Option("sheets", help="Output type: 'sheets' or 'csv'."),
+    resume: bool = typer.Option(True, help="When using Google Sheets, resume from last logged date."),
+    end_offset: int = typer.Option(1, help="How many days before today to use as end date (default 1 = yesterday).")
 ):
     """Run the Garmin sync from the command line."""
     user_profiles = load_user_profiles()
@@ -170,16 +217,28 @@ def cli_sync(
 
     email = selected_profile_data.get('email')
     password = selected_profile_data.get('password')
-
     if not email or not password:
         logger.error(f"Email or password not configured for profile '{profile}'.")
         sys.exit(1)
 
+    if start_date and end_date:
+        sd = start_date.date()
+        ed = end_date.date()
+    elif output_type == "sheets" and resume:
+        sd, ed = compute_resume_range(selected_profile_data, end_offset)
+    else:
+        logger.error("Must provide --start-date/--end-date for CSV, or use --resume with Sheets.")
+        sys.exit(1)
+
+    if ed < sd:
+        logger.info("Up to date — nothing to fetch.")
+        sys.exit(0)
+
     asyncio.run(sync(
         email=email,
         password=password,
-        start_date=start_date.date(),
-        end_date=end_date.date(),
+        start_date=sd,
+        end_date=ed,
         output_type=output_type,
         profile_data=selected_profile_data,
         profile_name=profile
@@ -236,30 +295,61 @@ async def run_interactive_sync():
     logger.info(f"Using profile: {selected_profile_name}")
 
     # Date Input
-    date_format = "%Y-%m-%d"
-    start_date = None
-    end_date = None
+    if output_type == "sheets":
+        use_resume = ""
+        while use_resume not in ["y", "n"]:
+            use_resume = input("Resume from last logged date? (y/n): ").strip().lower()
 
-    while True:
-        try:
-            start_date_str = input("Enter start date (YYYY-MM-DD): ")
-            start_date = datetime.strptime(start_date_str, date_format).date()
-            break
-        except ValueError:
-            print(f"Invalid date format. Please use {date_format}.")
+        if use_resume == "y":
+            try:
+                end_offset = int(input("Days before today to use as end date (default 1 = yesterday): ").strip())
+            except ValueError:
+                end_offset = 1
+            start_date, end_date = compute_resume_range(selected_profile_data, end_offset)
+        else:
+            date_format = "%Y-%m-%d"
+            while True:
+                try:
+                    start_date_str = input("Enter start date (YYYY-MM-DD): ")
+                    start_date = datetime.strptime(start_date_str, date_format).date()
+                    break
+                except ValueError:
+                    print(f"Invalid date format. Please use {date_format}.")
+            while True:
+                try:
+                    end_date_str = input("Enter end date (YYYY-MM-DD): ")
+                    end_date = datetime.strptime(end_date_str, date_format).date()
+                    if end_date >= start_date:
+                        break
+                    else:
+                        print("End date cannot be before start date.")
+                except ValueError:
+                    print(f"Invalid date format. Please use {date_format}.")
 
-    while True:
-        try:
-            end_date_str = input("Enter end date (YYYY-MM-DD): ")
-            end_date = datetime.strptime(end_date_str, date_format).date()
-            if end_date >= start_date:
+        logger.info(f"Date range selected: {start_date} to {end_date}")
+
+    else:
+        # CSV requires explicit dates
+        date_format = "%Y-%m-%d"
+        while True:
+            try:
+                start_date_str = input("Enter start date (YYYY-MM-DD): ")
+                start_date = datetime.strptime(start_date_str, date_format).date()
                 break
-            else:
-                print("End date cannot be before start date.")
-        except ValueError:
-            print(f"Invalid date format. Please use {date_format}.")
+            except ValueError:
+                print(f"Invalid date format. Please use {date_format}.")
+        while True:
+            try:
+                end_date_str = input("Enter end date (YYYY-MM-DD): ")
+                end_date = datetime.strptime(end_date_str, date_format).date()
+                if end_date >= start_date:
+                    break
+                else:
+                    print("End date cannot be before start date.")
+            except ValueError:
+                print(f"Invalid date format. Please use {date_format}.")
+        logger.info(f"Date range selected: {start_date.strftime(date_format)} to {end_date.strftime(date_format)}")
 
-    logger.info(f"Date range selected: {start_date.strftime(date_format)} to {end_date.strftime(date_format)}")
 
     # Call Core Sync Logic
     await sync(

--- a/src/sheets_client.py
+++ b/src/sheets_client.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 from pathlib import Path
 import pickle
-from datetime import date # Import the date type
+from datetime import datetime, date # Import the date type
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
@@ -14,6 +14,24 @@ from .config import GarminMetrics, HEADERS, HEADER_TO_ATTRIBUTE_MAP
 
 logger = logging.getLogger(__name__)
 SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
+
+# Normalize dates in the spreadsheet in case they are not in the right format
+def normalize_date(value: str) -> str:
+    """Try to normalize different date formats to ISO yyyy-mm-dd string."""
+    if not value:
+        return ""
+    try:
+        return datetime.fromisoformat(value).date().isoformat()
+    except Exception:
+        pass
+
+    for fmt in ("%b %d, %Y", "%B %d, %Y"):  # e.g. "Sep 28, 2025" or "September 28, 2025"
+        try:
+            return datetime.strptime(value.strip(), fmt).date().isoformat()
+        except ValueError:
+            continue
+
+    return value.strip()  # fallback: return raw if nothing matched
 
 class GoogleAuthTokenRefreshError(Exception):
     """Raised when the Google API token refresh fails."""
@@ -90,9 +108,17 @@ class GoogleSheetsClient:
         
         try:
             date_column_range = f"'{self.sheet_name}'!A:A"
-            result = self.service.spreadsheets().values().get(spreadsheetId=self.spreadsheet_id, range=date_column_range).execute()
+            result = self.service.spreadsheets().values().get(
+                spreadsheetId=self.spreadsheet_id, range=date_column_range
+            ).execute()
             existing_dates_list = result.get('values', [])
-            date_to_row_map = {row[0]: i + 1 for i, row in enumerate(existing_dates_list) if row}
+            date_to_row_map = {}
+            for i, row in enumerate(existing_dates_list):
+                if not row or not row[0]:
+                    continue
+                key = normalize_date(row[0])
+                date_to_row_map[key] = i + 1
+
         except HttpError as e:
             logger.error(f"Could not read existing dates from sheet: {e}")
             return


### PR DESCRIPTION
This PR introduces several improvements:

- **Resume sync logic**  
  Adds option to continue from the last logged date in Google Sheets, avoiding duplicates.  
  Default `--end-offset 1` ensures sync runs only up to yesterday.  

- **Date normalization**  
  Handles Google Sheets dates entered/formatted as `Sep 28, 2025` or `September 28, 2025`, normalizing to ISO `YYYY-MM-DD`.  
  Prevents duplicate rows when dates are formatted differently.  

- **Automation scripts for macOS**  
  - Added `run_garmingo.sh` to simplify running sync for multiple users.  
  - Added `com.garmingo.sync.plist` for `launchd` so macOS users can automate daily sync at a chosen time.  
  - Updated README with instructions for setting up the automation.  

These changes are backward-compatible and optional for users who prefer manual or Windows scheduled tasks.