### PR TITLE
Fix: Add token persistence to prevent repeated MFA prompts

### DIFF
--- a/src/garmin_client.py
+++ b/src/garmin_client.py
@@ -25,7 +25,7 @@ class GarminClient:
 
         try:
             def login_wrapper():
-                return self.client.login()
+                return self.client.login("~/.garth") # FIX: Passed "~/.garth" to force the client to load previously saved session tokens, bypassing the MFA prompt on subsequent runs.
             
             login_result = await asyncio.get_event_loop().run_in_executor(None, login_wrapper)
             
@@ -376,6 +376,7 @@ class GarminClient:
                 raise Exception("Critical error: Could not retrieve garth.Client instance from mfa_ticket_dict post MFA for token update.")
             
             self._authenticated = True
+            self.client.garth.dump("~/.garth") # FIX: Passed "~/.garth" to force the client to load previously saved session tokens, bypassing the MFA prompt on subsequent runs.
             self.mfa_ticket_dict = None # Clear the used MFA ticket dict
             logger.info("MFA verification successful. Garth client updated with authenticated instance.")
             return True


### PR DESCRIPTION
Fix: Add token persistence to avoid repeated MFA prompts

Hi there! Thank you for building such a useful tool for syncing Garmin data to Google Sheets.

I was setting this up to run automatically via cron on a headless server, but ran into an issue where the script would halt and ask for an MFA code every single time it ran, breaking the automation.

It looks like the session tokens generated by garth weren't being saved to the disk after a successful login, and the script wasn't looking for them on startup.

Changes:

Updated submit_mfa_code to call self.client.garth.dump("~/.garth") after a successful login, saving the session to the standard garth directory.

Updated the initial login_wrapper to call self.client.login("~/.garth"), allowing it to load the saved session and completely bypass the MFA challenge on subsequent runs.

Let me know if you need any changes made to this. Thanks again for your work on this project!