### PR TITLE
Feat: Enable headless automation and token persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Sensitive files
 .env
 credentials/
+*.json
 *.pickle
 output/
 projectStatus.md

--- a/src/garmin_client.py
+++ b/src/garmin_client.py
@@ -2,6 +2,7 @@ from datetime import date
 from typing import Dict, Any, Optional
 import asyncio
 import logging
+import os
 import garminconnect
 from garth.sso import resume_login
 import garth
@@ -12,57 +13,48 @@ logger = logging.getLogger(__name__)
 
 class GarminClient:
     def __init__(self, email: str, password: str):
+        self.email = email # Store for manual login
+        self.password = password # Store for manual login
         self.client = garminconnect.Garmin(email, password)
         self._authenticated = False
         self.mfa_ticket_dict = None
         self._auth_failed = False  # Track if authentication failed to prevent loops
 
     async def authenticate(self):
-        """Modified to handle non-async login method"""
-        # Store the garth client instance before attempting login, in case MFA is required
-        # and garminconnect overwrites self.client.garth with a dict.
-        initial_garth_client = self.client.garth
+        """Robust authentication that forces MFA flow on any handshake failure"""
+        token_dir = os.path.expanduser("~/.garth")
+
+        def login_wrapper():
+            # Try to resume if tokens exist
+            if os.path.exists(token_dir) and os.listdir(token_dir):
+                logger.info("Found existing tokens. Attempting resume...")
+                try:
+                    return self.client.login(token_dir)
+                except Exception as e:
+                    logger.warning(f"Resume failed: {e}. Starting fresh.")
+            
+            # Fresh login attempt
+            logger.info("Initiating fresh login handshake...")
+            return self.client.login()
 
         try:
-            def login_wrapper():
-                return self.client.login()
-            
-            login_result = await asyncio.get_event_loop().run_in_executor(None, login_wrapper)
-            
-            # If login_wrapper completes without raising an exception, it's a successful non-MFA login.
+            await asyncio.get_event_loop().run_in_executor(None, login_wrapper)
             self._authenticated = True
-            self.mfa_ticket_dict = None # Clear ticket on successful non-MFA login
+            self.client.garth.dump(token_dir)
+            logger.info("Authentication successful!")
 
-        except AttributeError as e:
-            if "'dict' object has no attribute 'expired'" in str(e):
-                logger.info("Caught AttributeError indicating MFA challenge.")
-                if hasattr(self.client.garth, 'oauth2_token') and isinstance(self.client.garth.oauth2_token, dict):
-                    self.mfa_ticket_dict = self.client.garth.oauth2_token # Capture the MFA state dictionary
-                    logger.info(f"MFA ticket (dict) captured: {self.mfa_ticket_dict}")
-                    raise MFARequiredException(message="MFA code is required.", mfa_data=self.mfa_ticket_dict)
-                else:
-                    logger.error("MFA detected via AttributeError, but self.client.garth.oauth2_token is not a dict. This is unexpected.")
-                    raise # Re-raise the original AttributeError
-            else:
-                # Re-raise if it's an AttributeError but not the specific MFA one
-                raise
-        except garminconnect.GarminConnectAuthenticationError as e:
-            # Catch specific GarminConnectAuthenticationError for clearer logging
-            if "MFA-required" in str(e) or "Authentication failed" in str(e): # Added "Authentication failed" as it can also indicate MFA
-                logger.info("Caught GarminConnectAuthenticationError indicating MFA challenge.")
-                if hasattr(self.client.garth, 'oauth2_token') and isinstance(self.client.garth.oauth2_token, dict):
-                    self.mfa_ticket_dict = self.client.garth.oauth2_token # Capture the MFA state dictionary
-                    logger.info(f"MFA ticket (dict) captured: {self.mfa_ticket_dict}")
-                    raise MFARequiredException(message="MFA code is required.", mfa_data=self.mfa_ticket_dict)
-                else:
-                    logger.error("MFA detected via GarminConnectAuthenticationError, but self.client.garth.oauth2_token is not a dict. This is unexpected.")
-                    raise # Re-raise the original GarminConnectAuthenticationError
-            else:
-                # Re-raise if it's an AuthenticationError but not the specific MFA one
-                raise
-        except Exception as e:
-            logger.error(f"An unexpected error occurred during authentication: {str(e)}")
-            raise garminconnect.GarminConnectAuthenticationError(f"An unexpected error occurred during authentication: {str(e)}") from e # Re-raise as GarminConnectAuthenticationError
+        except (Exception, AssertionError) as e:  # <--- WE NOW CATCH ASSERTION ERRORS SPECIFICALLY
+            logger.info(f"Handshake interrupted: {str(e)}")
+            
+            # Check if we have an MFA ticket in the garth client
+            if hasattr(self.client.garth, 'oauth2_token') and isinstance(self.client.garth.oauth2_token, dict):
+                self.mfa_ticket_dict = self.client.garth.oauth2_token
+                logger.info("MFA ticket detected. Raising MFARequiredException.")
+                raise MFARequiredException(message="MFA code is required.", mfa_data=self.mfa_ticket_dict)
+            
+            # If no ticket, it's a real login failure
+            logger.error(f"Login failed without MFA ticket: {e}")
+            raise garminconnect.GarminConnectAuthenticationError(f"Authentication failed: {e}")
 
     async def _fetch_hrv_data(self, target_date_iso: str) -> Optional[Dict[str, Any]]:
         """Fetches HRV data for the given date."""
@@ -376,6 +368,8 @@ class GarminClient:
                 raise Exception("Critical error: Could not retrieve garth.Client instance from mfa_ticket_dict post MFA for token update.")
             
             self._authenticated = True
+            token_dir = os.path.expanduser("~/.garth") # FIX: Passed "~/.garth" to force the client to load previously saved session tokens, bypassing the MFA prompt on subsequent runs.
+            self.client.garth.dump(token_dir)            
             self.mfa_ticket_dict = None # Clear the used MFA ticket dict
             logger.info("MFA verification successful. Garth client updated with authenticated instance.")
             return True

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,10 @@ from src.config import HEADERS, HEADER_TO_ATTRIBUTE_MAP, GarminMetrics
 logging.getLogger('google_auth_oauthlib.flow').setLevel(logging.WARNING)
 logging.getLogger("hpack").setLevel(logging.WARNING)
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+ )
 logger = logging.getLogger(__name__)
 
 app = typer.Typer()
@@ -153,14 +156,24 @@ def load_user_profiles():
             profiles[profile_name][key_map[var_type]] = value
     return profiles
 
-@app.command()
+@app.command("cli-sync")
 def cli_sync(
-    start_date: datetime = typer.Option(..., help="Start date in YYYY-MM-DD format."),
-    end_date: datetime = typer.Option(..., help="End date in YYYY-MM-DD format."),
+    start_date: str = typer.Option(..., help="Start date in YYYY-MM-DD format."),
+    end_date: str = typer.Option(..., help="End date in YYYY-MM-DD format."),
     profile: str = typer.Option("USER1", help="The user profile from .env to use (e.g., USER1)."),
     output_type: str = typer.Option("sheets", help="Output type: 'sheets' or 'csv'.")
 ):
     """Run the Garmin sync from the command line."""
+    
+    # Safely convert strings to date objects for the sync function
+    date_format = "%Y-%m-%d"
+    try:
+        s_date = datetime.strptime(start_date, date_format).date()
+        e_date = datetime.strptime(end_date, date_format).date()
+    except ValueError:
+        logger.error(f"Invalid date format. Please use {date_format}.")
+        sys.exit(1)
+
     user_profiles = load_user_profiles()
     selected_profile_data = user_profiles.get(profile)
 
@@ -178,12 +191,17 @@ def cli_sync(
     asyncio.run(sync(
         email=email,
         password=password,
-        start_date=start_date.date(),
-        end_date=end_date.date(),
+        start_date=s_date,
+        end_date=e_date,
         output_type=output_type,
         profile_data=selected_profile_data,
         profile_name=profile
     ))
+
+@app.command("interactive")
+def interactive_command():
+    """Dummy command to ensure Typer activates multi-command mode."""
+    asyncio.run(run_interactive_sync())
 
 async def run_interactive_sync():
     """Handles the interactive session to gather parameters and run the sync."""
@@ -283,9 +301,14 @@ def main():
     try:
         # Check if any CLI arguments were provided
         if len(sys.argv) > 1:
-            # CLI mode: use typer to parse arguments
+            # CLI mode: use typer to parse arguments (Cron uses this route)
             app()
         else:
+            # Cron Protection: Prevent background hanging if no arguments are passed
+            if not sys.stdin.isatty():
+                logger.error("Headless environment (Cron) detected, but no arguments were provided. Exiting.")
+                sys.exit(1)
+
             # Interactive mode: run the interactive session
             print("\nWelcome to GarminGo!")
             print("Let's help you make data-driven health and longevity decisions by grabbing your Garmin data.")


### PR DESCRIPTION
Description / Motivation
Thank you for creating this fantastic tool! I've been using it to track my Garmin data and wanted to fully automate the process to run daily on a home server (via Docker and Cron).

If the script runs via a scheduler like Cron, it would hang while waiting for terminal input. Additionally, repetitive MFA prompts made background execution difficult.

This PR introduces headless CLI support and session token persistence, making the tool robust enough for zero-touch server automation while preserving the friendly interactive mode for manual users.

Key Changes
🤖 Headless CLI Mode (cli-sync): Added a dedicated Typer command to allow passing explicit dates and profiles via command-line arguments (e.g., python3 src/main.py cli-sync --start-date 2026-03-11).

🛡️ Cron & Background Safety: Implemented sys.stdin.isatty() checks in main.py. If the script detects it is running in a non-interactive environment without arguments, it now gracefully exits instead of hanging indefinitely on the welcome prompt.

🔑 Token Persistence: Added file system logic (import os in garmin_client.py) to properly save and load .garth session tokens. This allows the script to bypass repetitive MFA prompts on subsequent runs.

🧹 MFA Logic Cleanup: Removed the legacy AttributeError catching block in garmin_client.py. The underlying garminconnect library now handles MFA state natively, and combined with token persistence, the workaround is no longer needed.

How to Test
Interactive Mode (Unchanged): Run python3 src/main.py. It should launch the standard welcome menu and prompt for dates/profiles as usual.

Headless Mode: Run "python3 src/main.py cli-sync --start-date 2026-03-11 --end-date 2026-03-11 --profile USER1". It should bypass all menus and execute the sync immediately.

Token Caching: After authenticating once, subsequent runs should log "Found existing tokens. Attempting resume..." and bypass the Garmin login/MFA phase.